### PR TITLE
fix async method

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ PrivateKeyProvider.prototype.sendAsync = function() {
 };
 
 PrivateKeyProvider.prototype.send = function() {
-  return this.engine.send.apply(this.engine, arguments);
+  return this.engine.sendAsync.apply(this.engine, arguments);
 };
 
 


### PR DESCRIPTION
Relate to this issue(https://github.com/nosuchip/truffle-privatekey-provider/issues/7) happen when you try to deploy to testnet or mainnet (eg anything else ganache).
I'm sure it's not good but it's work, just bored about the poor quality of Ethereum tools ecosystem.